### PR TITLE
Add ucHome, ucCourseInfo and draft ucCourseInfo

### DIFF
--- a/Elearning.csproj
+++ b/Elearning.csproj
@@ -63,6 +63,24 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UserControls\ucCourseInfo.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\ucCourseInfo.Designer.cs">
+      <DependentUpon>ucCourseInfo.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UserControls\ucCoursePreview.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\ucCoursePreview.Designer.cs">
+      <DependentUpon>ucCoursePreview.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UserControls\ucHome.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\ucHome.Designer.cs">
+      <DependentUpon>ucHome.cs</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\ucMain.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -85,6 +103,15 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <EmbeddedResource Include="UserControls\ucCourseInfo.resx">
+      <DependentUpon>ucCourseInfo.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserControls\ucCoursePreview.resx">
+      <DependentUpon>ucCoursePreview.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserControls\ucHome.resx">
+      <DependentUpon>ucHome.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="UserControls\ucMain.resx">
       <DependentUpon>ucMain.cs</DependentUpon>
     </EmbeddedResource>

--- a/Forms/fMain.Designer.cs
+++ b/Forms/fMain.Designer.cs
@@ -30,11 +30,11 @@
         {
             this.panelTop = new System.Windows.Forms.Panel();
             this.lbUserFullname = new System.Windows.Forms.Label();
-            this.panelMain = new System.Windows.Forms.Panel();
-            this.label1 = new System.Windows.Forms.Label();
             this.btnUserProfile = new Siticone.Desktop.UI.WinForms.SiticoneCirclePictureBox();
+            this.lbAppName = new System.Windows.Forms.Label();
             this.siticoneContainerControl1 = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
             this.btnNoti = new Siticone.Desktop.UI.WinForms.SiticoneButton();
+            this.panelMain = new System.Windows.Forms.Panel();
             this.panelTop.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.btnUserProfile)).BeginInit();
             this.siticoneContainerControl1.SuspendLayout();
@@ -45,7 +45,7 @@
             this.panelTop.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(238)))), ((int)(((byte)(245)))), ((int)(((byte)(255)))));
             this.panelTop.Controls.Add(this.lbUserFullname);
             this.panelTop.Controls.Add(this.btnUserProfile);
-            this.panelTop.Controls.Add(this.label1);
+            this.panelTop.Controls.Add(this.lbAppName);
             this.panelTop.Controls.Add(this.siticoneContainerControl1);
             this.panelTop.Dock = System.Windows.Forms.DockStyle.Top;
             this.panelTop.Location = new System.Drawing.Point(0, 0);
@@ -67,27 +67,6 @@
             this.lbUserFullname.Text = "Nguyễn Văn A";
             this.lbUserFullname.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // panelMain
-            // 
-            this.panelMain.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelMain.Location = new System.Drawing.Point(0, 50);
-            this.panelMain.Name = "panelMain";
-            this.panelMain.Size = new System.Drawing.Size(1228, 629);
-            this.panelMain.TabIndex = 1;
-            // 
-            // label1
-            // 
-            this.label1.Dock = System.Windows.Forms.DockStyle.Left;
-            this.label1.Font = new System.Drawing.Font("UTM Cooper Black", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(29)))), ((int)(((byte)(36)))), ((int)(((byte)(202)))));
-            this.label1.Location = new System.Drawing.Point(0, 0);
-            this.label1.Name = "label1";
-            this.label1.Padding = new System.Windows.Forms.Padding(15, 0, 0, 0);
-            this.label1.Size = new System.Drawing.Size(176, 50);
-            this.label1.TabIndex = 3;
-            this.label1.Text = "E-Learning";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
             // btnUserProfile
             // 
             this.btnUserProfile.Cursor = System.Windows.Forms.Cursors.Hand;
@@ -100,6 +79,21 @@
             this.btnUserProfile.Size = new System.Drawing.Size(50, 50);
             this.btnUserProfile.TabIndex = 6;
             this.btnUserProfile.TabStop = false;
+            // 
+            // lbAppName
+            // 
+            this.lbAppName.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.lbAppName.Dock = System.Windows.Forms.DockStyle.Left;
+            this.lbAppName.Font = new System.Drawing.Font("UTM Cooper Black", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbAppName.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(29)))), ((int)(((byte)(36)))), ((int)(((byte)(202)))));
+            this.lbAppName.Location = new System.Drawing.Point(0, 0);
+            this.lbAppName.Name = "lbAppName";
+            this.lbAppName.Padding = new System.Windows.Forms.Padding(15, 0, 0, 0);
+            this.lbAppName.Size = new System.Drawing.Size(176, 50);
+            this.lbAppName.TabIndex = 3;
+            this.lbAppName.Text = "E-Learning";
+            this.lbAppName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lbAppName.Click += new System.EventHandler(this.lbAppName_Click);
             // 
             // siticoneContainerControl1
             // 
@@ -131,6 +125,14 @@
             this.btnNoti.Size = new System.Drawing.Size(42, 42);
             this.btnNoti.TabIndex = 8;
             // 
+            // panelMain
+            // 
+            this.panelMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelMain.Location = new System.Drawing.Point(0, 50);
+            this.panelMain.Name = "panelMain";
+            this.panelMain.Size = new System.Drawing.Size(1228, 629);
+            this.panelMain.TabIndex = 1;
+            // 
             // fMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -154,7 +156,7 @@
         private System.Windows.Forms.Panel panelTop;
         private System.Windows.Forms.Label lbUserFullname;
         private System.Windows.Forms.Panel panelMain;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label lbAppName;
         private Siticone.Desktop.UI.WinForms.SiticoneCirclePictureBox btnUserProfile;
         private Siticone.Desktop.UI.WinForms.SiticoneContainerControl siticoneContainerControl1;
         private Siticone.Desktop.UI.WinForms.SiticoneButton btnNoti;

--- a/Forms/fMain.cs
+++ b/Forms/fMain.cs
@@ -13,6 +13,7 @@ namespace Elearning
 {
     public partial class fMain : Form
     {
+        private ucMain ucMain;
         public fMain()
         {
             InitializeComponent();
@@ -20,9 +21,31 @@ namespace Elearning
 
         private void fMain_Load(object sender, EventArgs e)
         {
-            ucMain ucMain = new ucMain();
-            ucMain.Dock = DockStyle.Fill;
+            this.ucMain = new ucMain();
+            this.ucMain.Dock = DockStyle.Fill;
+            this.ucMain.viewDetailsClicked += ucCoursePreview_viewDetailsClicked;
             panelMain.Controls.Add(ucMain);
         }
+
+        private void ucCoursePreview_viewDetailsClicked(object sender, EventArgs e)
+        {
+            panelMain.Controls.Clear();
+            ucCourseInfo ucCourseInfo = new ucCourseInfo();
+            ucCourseInfo.Dock = DockStyle.Fill;
+            ucCourseInfo.backHomeClicked += ucCourseInfo_backHomeClicked;
+            panelMain.Controls.Add(ucCourseInfo);
+        }
+        private void lbAppName_Click(object sender, EventArgs e)
+        {
+            panelMain.Controls.Clear();
+            panelMain.Controls.Add(this.ucMain);
+        }
+
+        private void ucCourseInfo_backHomeClicked(object sender, EventArgs e)
+        {
+            panelMain.Controls.Clear();
+            panelMain.Controls.Add(this.ucMain);
+        }
+
     }
 }

--- a/UserControls/ucCourseInfo.Designer.cs
+++ b/UserControls/ucCourseInfo.Designer.cs
@@ -1,0 +1,194 @@
+﻿namespace Elearning.UserControls
+{
+    partial class ucCourseInfo
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lbCourseName = new System.Windows.Forms.Label();
+            this.lbLecturer = new System.Windows.Forms.Label();
+            this.conTop = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
+            this.siticoneContainerControl2 = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
+            this.siticoneContainerControl3 = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
+            this.siticoneContainerControl4 = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
+            this.btnBackHome = new Siticone.Desktop.UI.WinForms.SiticoneButton();
+            this.btnRegister = new Siticone.Desktop.UI.WinForms.SiticoneButton();
+            this.siticoneContainerControl1 = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
+            this.conTop.SuspendLayout();
+            this.siticoneContainerControl2.SuspendLayout();
+            this.siticoneContainerControl3.SuspendLayout();
+            this.siticoneContainerControl4.SuspendLayout();
+            this.siticoneContainerControl1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // lbCourseName
+            // 
+            this.lbCourseName.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lbCourseName.Font = new System.Drawing.Font("UTM Cooper Black", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbCourseName.Location = new System.Drawing.Point(0, 0);
+            this.lbCourseName.Name = "lbCourseName";
+            this.lbCourseName.Padding = new System.Windows.Forms.Padding(10, 0, 10, 0);
+            this.lbCourseName.Size = new System.Drawing.Size(982, 43);
+            this.lbCourseName.TabIndex = 0;
+            this.lbCourseName.Text = "Introduction to Programming with C++: Basic mini course I";
+            this.lbCourseName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lbLecturer
+            // 
+            this.lbLecturer.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lbLecturer.Font = new System.Drawing.Font("Segoe UI Variable Display Semib", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbLecturer.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.lbLecturer.Location = new System.Drawing.Point(0, 43);
+            this.lbLecturer.Name = "lbLecturer";
+            this.lbLecturer.Padding = new System.Windows.Forms.Padding(10, 0, 10, 0);
+            this.lbLecturer.Size = new System.Drawing.Size(982, 24);
+            this.lbLecturer.TabIndex = 1;
+            this.lbLecturer.Text = "Prof. Nguyen Tran Dang Vo";
+            // 
+            // conTop
+            // 
+            this.conTop.BackColor = System.Drawing.Color.Transparent;
+            this.conTop.Controls.Add(this.siticoneContainerControl1);
+            this.conTop.Controls.Add(this.siticoneContainerControl2);
+            this.conTop.Dock = System.Windows.Forms.DockStyle.Top;
+            this.conTop.FillColor = System.Drawing.Color.Transparent;
+            this.conTop.Location = new System.Drawing.Point(0, 0);
+            this.conTop.Name = "conTop";
+            this.conTop.Size = new System.Drawing.Size(1233, 80);
+            this.conTop.TabIndex = 2;
+            this.conTop.Text = "siticoneContainerControl1";
+            // 
+            // siticoneContainerControl2
+            // 
+            this.siticoneContainerControl2.Controls.Add(this.siticoneContainerControl4);
+            this.siticoneContainerControl2.Controls.Add(this.siticoneContainerControl3);
+            this.siticoneContainerControl2.Dock = System.Windows.Forms.DockStyle.Right;
+            this.siticoneContainerControl2.FillColor = System.Drawing.Color.Transparent;
+            this.siticoneContainerControl2.Location = new System.Drawing.Point(982, 0);
+            this.siticoneContainerControl2.Name = "siticoneContainerControl2";
+            this.siticoneContainerControl2.Padding = new System.Windows.Forms.Padding(0, 5, 4, 5);
+            this.siticoneContainerControl2.Size = new System.Drawing.Size(251, 80);
+            this.siticoneContainerControl2.TabIndex = 1;
+            this.siticoneContainerControl2.Text = "siticoneContainerControl2";
+            // 
+            // siticoneContainerControl3
+            // 
+            this.siticoneContainerControl3.Controls.Add(this.btnBackHome);
+            this.siticoneContainerControl3.Dock = System.Windows.Forms.DockStyle.Right;
+            this.siticoneContainerControl3.FillColor = System.Drawing.Color.Transparent;
+            this.siticoneContainerControl3.Location = new System.Drawing.Point(127, 5);
+            this.siticoneContainerControl3.Name = "siticoneContainerControl3";
+            this.siticoneContainerControl3.Padding = new System.Windows.Forms.Padding(3);
+            this.siticoneContainerControl3.Size = new System.Drawing.Size(120, 70);
+            this.siticoneContainerControl3.TabIndex = 0;
+            this.siticoneContainerControl3.Text = "siticoneContainerControl3";
+            // 
+            // siticoneContainerControl4
+            // 
+            this.siticoneContainerControl4.Controls.Add(this.btnRegister);
+            this.siticoneContainerControl4.Dock = System.Windows.Forms.DockStyle.Right;
+            this.siticoneContainerControl4.FillColor = System.Drawing.Color.Transparent;
+            this.siticoneContainerControl4.Location = new System.Drawing.Point(7, 5);
+            this.siticoneContainerControl4.Name = "siticoneContainerControl4";
+            this.siticoneContainerControl4.Padding = new System.Windows.Forms.Padding(3);
+            this.siticoneContainerControl4.Size = new System.Drawing.Size(120, 70);
+            this.siticoneContainerControl4.TabIndex = 3;
+            this.siticoneContainerControl4.Text = "Enroll now";
+            // 
+            // btnBackHome
+            // 
+            this.btnBackHome.BorderRadius = 2;
+            this.btnBackHome.DisabledState.BorderColor = System.Drawing.Color.DarkGray;
+            this.btnBackHome.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray;
+            this.btnBackHome.DisabledState.FillColor = System.Drawing.Color.FromArgb(((int)(((byte)(169)))), ((int)(((byte)(169)))), ((int)(((byte)(169)))));
+            this.btnBackHome.DisabledState.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(141)))), ((int)(((byte)(141)))), ((int)(((byte)(141)))));
+            this.btnBackHome.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnBackHome.Font = new System.Drawing.Font("Segoe UI Variable Display Semib", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnBackHome.ForeColor = System.Drawing.Color.White;
+            this.btnBackHome.Location = new System.Drawing.Point(3, 3);
+            this.btnBackHome.Name = "btnBackHome";
+            this.btnBackHome.Size = new System.Drawing.Size(114, 64);
+            this.btnBackHome.TabIndex = 0;
+            this.btnBackHome.Text = "Back to home";
+            this.btnBackHome.Click += new System.EventHandler(this.btnBackHome_Click);
+            // 
+            // btnRegister
+            // 
+            this.btnRegister.BorderRadius = 2;
+            this.btnRegister.DisabledState.BorderColor = System.Drawing.Color.DarkGray;
+            this.btnRegister.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray;
+            this.btnRegister.DisabledState.FillColor = System.Drawing.Color.FromArgb(((int)(((byte)(169)))), ((int)(((byte)(169)))), ((int)(((byte)(169)))));
+            this.btnRegister.DisabledState.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(141)))), ((int)(((byte)(141)))), ((int)(((byte)(141)))));
+            this.btnRegister.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnRegister.Font = new System.Drawing.Font("Segoe UI Variable Display Semib", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnRegister.ForeColor = System.Drawing.Color.White;
+            this.btnRegister.Location = new System.Drawing.Point(3, 3);
+            this.btnRegister.Name = "btnRegister";
+            this.btnRegister.Size = new System.Drawing.Size(114, 64);
+            this.btnRegister.TabIndex = 0;
+            this.btnRegister.Text = "Register";
+            // 
+            // siticoneContainerControl1
+            // 
+            this.siticoneContainerControl1.Controls.Add(this.lbLecturer);
+            this.siticoneContainerControl1.Controls.Add(this.lbCourseName);
+            this.siticoneContainerControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.siticoneContainerControl1.FillColor = System.Drawing.Color.Transparent;
+            this.siticoneContainerControl1.Location = new System.Drawing.Point(0, 0);
+            this.siticoneContainerControl1.Name = "siticoneContainerControl1";
+            this.siticoneContainerControl1.Size = new System.Drawing.Size(982, 80);
+            this.siticoneContainerControl1.TabIndex = 2;
+            this.siticoneContainerControl1.Text = "siticoneContainerControl1";
+            // 
+            // ucCourseInfo
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.conTop);
+            this.Name = "ucCourseInfo";
+            this.Size = new System.Drawing.Size(1233, 667);
+            this.conTop.ResumeLayout(false);
+            this.siticoneContainerControl2.ResumeLayout(false);
+            this.siticoneContainerControl3.ResumeLayout(false);
+            this.siticoneContainerControl4.ResumeLayout(false);
+            this.siticoneContainerControl1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lbCourseName;
+        private System.Windows.Forms.Label lbLecturer;
+        private Siticone.Desktop.UI.WinForms.SiticoneContainerControl conTop;
+        private Siticone.Desktop.UI.WinForms.SiticoneContainerControl siticoneContainerControl2;
+        private Siticone.Desktop.UI.WinForms.SiticoneContainerControl siticoneContainerControl1;
+        private Siticone.Desktop.UI.WinForms.SiticoneContainerControl siticoneContainerControl4;
+        private Siticone.Desktop.UI.WinForms.SiticoneButton btnRegister;
+        private Siticone.Desktop.UI.WinForms.SiticoneContainerControl siticoneContainerControl3;
+        private Siticone.Desktop.UI.WinForms.SiticoneButton btnBackHome;
+    }
+}

--- a/UserControls/ucCourseInfo.cs
+++ b/UserControls/ucCourseInfo.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Elearning.UserControls
+{
+    public partial class ucCourseInfo : UserControl
+    {
+        public EventHandler backHomeClicked;
+        public ucCourseInfo()
+        {
+            InitializeComponent();
+        }
+
+        private void btnBackHome_Click(object sender, EventArgs e)
+        {
+            backHomeClicked?.Invoke(this, e);
+        }
+    }
+}

--- a/UserControls/ucCourseInfo.resx
+++ b/UserControls/ucCourseInfo.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/UserControls/ucCoursePreview.Designer.cs
+++ b/UserControls/ucCoursePreview.Designer.cs
@@ -1,0 +1,133 @@
+﻿namespace Elearning.UserControls
+{
+    partial class ucCoursePreview
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.conInfo = new Siticone.Desktop.UI.WinForms.SiticoneContainerControl();
+            this.lbLecturer = new System.Windows.Forms.Label();
+            this.lbCourseName = new System.Windows.Forms.Label();
+            this.btnViewDetails = new Siticone.Desktop.UI.WinForms.SiticoneButton();
+            this.pbImaga = new Siticone.Desktop.UI.WinForms.SiticonePictureBox();
+            this.conInfo.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pbImaga)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // conInfo
+            // 
+            this.conInfo.Controls.Add(this.btnViewDetails);
+            this.conInfo.Controls.Add(this.lbCourseName);
+            this.conInfo.Controls.Add(this.lbLecturer);
+            this.conInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.conInfo.FillColor = System.Drawing.Color.Transparent;
+            this.conInfo.Location = new System.Drawing.Point(10, 127);
+            this.conInfo.Name = "conInfo";
+            this.conInfo.Padding = new System.Windows.Forms.Padding(4, 10, 4, 5);
+            this.conInfo.Size = new System.Drawing.Size(228, 111);
+            this.conInfo.TabIndex = 1;
+            this.conInfo.Text = "siticoneContainerControl1";
+            // 
+            // lbLecturer
+            // 
+            this.lbLecturer.BackColor = System.Drawing.Color.Transparent;
+            this.lbLecturer.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lbLecturer.Font = new System.Drawing.Font("Segoe UI Symbol", 7.8F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbLecturer.Location = new System.Drawing.Point(4, 10);
+            this.lbLecturer.Name = "lbLecturer";
+            this.lbLecturer.Size = new System.Drawing.Size(220, 10);
+            this.lbLecturer.TabIndex = 0;
+            this.lbLecturer.Text = "Prof. Nguyen Tran Dang Vo";
+            this.lbLecturer.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lbCourseName
+            // 
+            this.lbCourseName.BackColor = System.Drawing.Color.Transparent;
+            this.lbCourseName.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lbCourseName.Font = new System.Drawing.Font("Segoe UI Variable Display Semib", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbCourseName.Location = new System.Drawing.Point(4, 20);
+            this.lbCourseName.Name = "lbCourseName";
+            this.lbCourseName.Size = new System.Drawing.Size(220, 50);
+            this.lbCourseName.TabIndex = 1;
+            this.lbCourseName.Text = "Introduction to Programming with C++: Basic mini course I";
+            this.lbCourseName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // btnViewDetails
+            // 
+            this.btnViewDetails.DisabledState.BorderColor = System.Drawing.Color.DarkGray;
+            this.btnViewDetails.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray;
+            this.btnViewDetails.DisabledState.FillColor = System.Drawing.Color.FromArgb(((int)(((byte)(169)))), ((int)(((byte)(169)))), ((int)(((byte)(169)))));
+            this.btnViewDetails.DisabledState.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(141)))), ((int)(((byte)(141)))), ((int)(((byte)(141)))));
+            this.btnViewDetails.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.btnViewDetails.FillColor = System.Drawing.Color.FromArgb(((int)(((byte)(29)))), ((int)(((byte)(36)))), ((int)(((byte)(202)))));
+            this.btnViewDetails.Font = new System.Drawing.Font("Segoe UI Variable Display Semib", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnViewDetails.ForeColor = System.Drawing.Color.White;
+            this.btnViewDetails.Location = new System.Drawing.Point(4, 71);
+            this.btnViewDetails.Name = "btnViewDetails";
+            this.btnViewDetails.Size = new System.Drawing.Size(220, 35);
+            this.btnViewDetails.TabIndex = 2;
+            this.btnViewDetails.Text = "View details";
+            this.btnViewDetails.Click += new System.EventHandler(this.btnViewDetails_Click);
+            // 
+            // pbImaga
+            // 
+            this.pbImaga.BackColor = System.Drawing.Color.Transparent;
+            this.pbImaga.BorderRadius = 6;
+            this.pbImaga.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pbImaga.ImageRotate = 0F;
+            this.pbImaga.Location = new System.Drawing.Point(10, 10);
+            this.pbImaga.Name = "pbImaga";
+            this.pbImaga.Size = new System.Drawing.Size(228, 117);
+            this.pbImaga.TabIndex = 0;
+            this.pbImaga.TabStop = false;
+            // 
+            // ucCoursePreview
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.Controls.Add(this.conInfo);
+            this.Controls.Add(this.pbImaga);
+            this.Margin = new System.Windows.Forms.Padding(8, 10, 8, 10);
+            this.Name = "ucCoursePreview";
+            this.Padding = new System.Windows.Forms.Padding(10);
+            this.Size = new System.Drawing.Size(248, 248);
+            this.conInfo.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.pbImaga)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Siticone.Desktop.UI.WinForms.SiticonePictureBox pbImaga;
+        private Siticone.Desktop.UI.WinForms.SiticoneContainerControl conInfo;
+        private System.Windows.Forms.Label lbCourseName;
+        private System.Windows.Forms.Label lbLecturer;
+        private Siticone.Desktop.UI.WinForms.SiticoneButton btnViewDetails;
+    }
+}

--- a/UserControls/ucCoursePreview.cs
+++ b/UserControls/ucCoursePreview.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Elearning.UserControls
+{
+    public partial class ucCoursePreview : UserControl
+    {
+        public EventHandler viewDetailsClicked;
+        public ucCoursePreview()
+        {
+            InitializeComponent();
+        }
+
+        private void btnViewDetails_Click(object sender, EventArgs e)
+        {
+            viewDetailsClicked?.Invoke(this, e);
+        }
+    }
+}

--- a/UserControls/ucCoursePreview.resx
+++ b/UserControls/ucCoursePreview.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/UserControls/ucHome.Designer.cs
+++ b/UserControls/ucHome.Designer.cs
@@ -1,0 +1,59 @@
+﻿namespace Elearning.UserControls
+{
+    partial class ucHome
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.flowLayout = new System.Windows.Forms.FlowLayoutPanel();
+            this.SuspendLayout();
+            // 
+            // flowLayout
+            // 
+            this.flowLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayout.Location = new System.Drawing.Point(0, 0);
+            this.flowLayout.Name = "flowLayout";
+            this.flowLayout.Padding = new System.Windows.Forms.Padding(5);
+            this.flowLayout.Size = new System.Drawing.Size(1101, 667);
+            this.flowLayout.TabIndex = 0;
+            // 
+            // ucHome
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.flowLayout);
+            this.Name = "ucHome";
+            this.Size = new System.Drawing.Size(1101, 667);
+            this.Load += new System.EventHandler(this.ucHome_Load);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel flowLayout;
+    }
+}

--- a/UserControls/ucHome.cs
+++ b/UserControls/ucHome.cs
@@ -10,21 +10,26 @@ using System.Windows.Forms;
 
 namespace Elearning.UserControls
 {
-    public partial class ucMain : UserControl
+    public partial class ucHome : UserControl
     {
         public EventHandler viewDetailsClicked;
-        public ucMain()
+        public ucHome()
         {
             InitializeComponent();
+            this.flowLayout.AutoScroll = true;
+            this.flowLayout.VerticalScroll.Visible = true;
         }
 
-        private void ucMain_Load(object sender, EventArgs e)
+        private void ucHome_Load(object sender, EventArgs e)
         {
-            // set ucHome to the tabHome
-            ucHome ucHome = new ucHome();
-            ucHome.Dock = DockStyle.Fill;
-            ucHome.viewDetailsClicked += ucCoursePreview_viewDetailsClicked;
-            tabHome.Controls.Add(ucHome);
+            for (int i = 0; i < 10; i++)
+            {
+                ucCoursePreview item = new ucCoursePreview();
+                item.Dock = DockStyle.Top;
+                item.viewDetailsClicked += ucCoursePreview_viewDetailsClicked;
+                this.flowLayout.Controls.Add(item);
+            }
+
         }
 
         private void ucCoursePreview_viewDetailsClicked(object sender, EventArgs e)

--- a/UserControls/ucHome.resx
+++ b/UserControls/ucHome.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
- Complete UI of `ucHome` and `ucCoursePreview`. `ucHome` now list all sample `ucCoursePreview`s (no database connection yet). Each `ucCoursePreviews` is a square containing a course image, lecturer's name and course's name.
- `ucCourseInfo` currently is just a draft version that only displays course's and lecturer's names. Only `Back to home` feature is implemented. Will add more information later when receiving teacher's requirements